### PR TITLE
chore(ci): use workflow GH token for MacOS tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,5 +25,6 @@ jobs:
         run: python --version
 
       - name: Run unit tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./install.py --test-only --verbose
-        if: ${{ !startsWith(runner.os, 'macos') }}


### PR DESCRIPTION
This change enables using the ephemeral GH token in unit testing for MacOS (and other platforms). Ideally all tests should continue to pass, *and* utilize the new code that passes along the GH token without running into rate-limits.